### PR TITLE
Create user and group maps before starting dind

### DIFF
--- a/Dockerfile.dind
+++ b/Dockerfile.dind
@@ -35,6 +35,9 @@ RUN wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/di
 	&& rm -rf /usr/local/bin/*.bak \
 	&& chmod +x /usr/local/bin/dind
 
+RUN touch /etc/subuid \
+	&& touch /etc/subgid
+
 EXPOSE 2375
 
 COPY config /etc/docker/daemon/config


### PR DESCRIPTION
`/etc/subuid` and `/etc/subgid` need to exist before `userns-remap` is enabled and starting the docker daemon (docker/docker#20861).

If they don't, docker will fail to start with:

```
Error starting daemon:
  Error during "dockremap" user creation:
  Couldn't create subordinate ID ranges:
  Error while looking for subuid ranges for user "dockremap":
  open /etc/subuid: no such file or directory
```
