### PR TITLE
Dockerfile.dev: install clean-css-cli instead of clean-css

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 FROM mhart/alpine-node:latest
 
 RUN npm install --global \
-	clean-css \
+	clean-css-cli \
 	uglify-js


### PR DESCRIPTION
In clean-css 4.0, the CLI script which we depend on was split out into a
separate package, clean-css-cli.[0] Install this instead.

[0]
https://github.com/jakubpawlowicz/clean-css#important-40-breaking-changes

Signed-off-by: Andrew Donnellan <andrew@donnellan.id.au>