### PR TITLE
Fix staticcheck error

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func certPool(caFile string) (*x509.CertPool, error) {
 	certPool := x509.NewCertPool()
 	pem, err := ioutil.ReadFile(caFile)
 	if err != nil {
-		return nil, fmt.Errorf("Could not read CA certificate %q: %v", caFile, err)
+		return nil, fmt.Errorf("could not read CA certificate %q: %v", caFile, err)
 	}
 	if !certPool.AppendCertsFromPEM(pem) {
 		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", caFile)


### PR DESCRIPTION
This fixes the following staticcheck error:

main.go:155:25: error strings should not be capitalized (ST1005)

This hopefully lets [contained.af](https://contained.af) come back to life.