### PR TITLE
add noopener noreferrer to link

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,7 +62,7 @@
                     <div class="col-md-2"></div>
                     <div class="col-md-5">
                         <p>Have an idea for a good question? Make a pull request
-                        to <a href="https://github.com/genuinetools/contained.af" target="_blank">github.com/genuinetools/contained.af</a>.</p>
+                        to <a href="https://github.com/genuinetools/contained.af" target="_blank" rel="noopener noreferrer">github.com/genuinetools/contained.af</a>.</p>
                     </div>
                 </div>
             </footer>


### PR DESCRIPTION
This prevents tab nabbing on links with target="_blank".

"noreferrer" is usually advocated for older browsers (ie, IE 11) that don't support "noopener", so if we don't care about older browsers, I can easily remove the "noreferrer" from this PR.